### PR TITLE
Fixes issue #24.

### DIFF
--- a/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/DuplicateInjectsFromIncludedModuleFails.csproj
+++ b/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/DuplicateInjectsFromIncludedModuleFails.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{397FACB5-4857-446D-9B52-263F5D7CE12D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DuplicateInjectsFromIncludedModuleFails</RootNamespace>
+    <AssemblyName>DuplicateInjectsFromIncludedModuleFails</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestFile.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Stiletto\Stiletto.csproj">
+      <Project>{b661e302-2234-48d3-8be4-684c0963eb35}</Project>
+      <Name>Stiletto</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ExpectedResults.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/ExpectedResults.xml
+++ b/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/ExpectedResults.xml
@@ -1,0 +1,5 @@
+﻿<ExpectedResults>
+  <Errors>
+  	<Pattern>The type [^\s]+ is provided more than once</Pattern>
+  </Errors>
+</ExpectedResults>

--- a/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/Properties/AssemblyInfo.cs
+++ b/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DuplicateInjectsFromIncludedModuleFails")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DuplicateInjectsFromIncludedModuleFails")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("16bfaa75-7b6b-4786-8b64-d85f949bd79d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/TestFile.cs
+++ b/IntegrationTests/DuplicateInjectsFromInIncludedModuleFails/TestFile.cs
@@ -1,0 +1,30 @@
+﻿using Stiletto;
+
+namespace DuplicateInjectsFromIncludedModuleFails
+{
+    public class InjectableClass
+    {
+        [Inject]
+        public string Foo { get; set; }
+    }
+
+    [Module(
+        Injects = new[] { typeof(InjectableClass) },
+        IncludedModules = new[] { typeof(IncludedModule) })]
+    public class MainModule
+    {
+        [Provides]
+        public string ProvideString()
+        {
+            return "foo";
+        }
+    }
+
+    [Module(
+        Injects = new[] {typeof (InjectableClass)},
+        IsComplete = false)]
+    public class IncludedModule
+    {
+        
+    }
+}

--- a/IntegrationTests/DuplicateInjectsTypesFail/DuplicateInjectsTypesFail.csproj
+++ b/IntegrationTests/DuplicateInjectsTypesFail/DuplicateInjectsTypesFail.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{47052838-D044-4399-AE69-17BD457A2265}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DuplicateInjectsTypesFail</RootNamespace>
+    <AssemblyName>DuplicateInjectsTypesFail</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TestFile.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Stiletto\Stiletto.csproj">
+      <Project>{b661e302-2234-48d3-8be4-684c0963eb35}</Project>
+      <Name>Stiletto</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ExpectedResults.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/IntegrationTests/DuplicateInjectsTypesFail/ExpectedResults.xml
+++ b/IntegrationTests/DuplicateInjectsTypesFail/ExpectedResults.xml
@@ -1,0 +1,5 @@
+﻿<ExpectedResults>
+  <Errors>
+  	<Pattern>The type [^\s]+ is provided more than once</Pattern>
+  </Errors>
+</ExpectedResults>

--- a/IntegrationTests/DuplicateInjectsTypesFail/Properties/AssemblyInfo.cs
+++ b/IntegrationTests/DuplicateInjectsTypesFail/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("DuplicateInjectsTypesFail")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DuplicateInjectsTypesFail")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("16bfaa75-7b6b-4786-8b64-d85f949bd79d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/IntegrationTests/DuplicateInjectsTypesFail/TestFile.cs
+++ b/IntegrationTests/DuplicateInjectsTypesFail/TestFile.cs
@@ -1,0 +1,20 @@
+﻿using Stiletto;
+
+namespace DuplicateInjectsTypesFail
+{
+    public class InjectableClass
+    {
+        [Inject]
+        public string Foo { get; set; }
+    }
+
+    [Module(Injects = new[] { typeof(InjectableClass), typeof(InjectableClass) })]
+    public class MainModule
+    {
+        [Provides]
+        public string ProvideString()
+        {
+            return "foo";
+        }
+    }
+}

--- a/Stiletto.Fody/Generators/ModuleGenerator.cs
+++ b/Stiletto.Fody/Generators/ModuleGenerator.cs
@@ -154,6 +154,15 @@ namespace Stiletto.Fody.Generators
                 moduleCtor = Import(moduleCtor);
             }
 
+            var injectTypeSet = new HashSet<TypeReference>(new TypeReferenceComparer());
+            foreach (var injectType in Injects)
+            {
+                if (!injectTypeSet.Add(injectType))
+                {
+                    errorReporter.LogError(moduleType.FullName + ": The type " + injectType.FullName + " is provided more than once.");
+                }
+            }
+
             ProvidedKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (var method in baseProvidesMethods)
             {

--- a/Stiletto.sln
+++ b/Stiletto.sln
@@ -46,6 +46,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnusedBindingsInLibraryModu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModulesNeedDefaultConstructors", "IntegrationTests\ModulesNeedDefaultConstructors\ModulesNeedDefaultConstructors.csproj", "{F2B7A491-F65E-4E90-86FB-C3DA8C7E2F88}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DuplicateInjectsTypesFail", "IntegrationTests\DuplicateInjectsTypesFail\DuplicateInjectsTypesFail.csproj", "{47052838-D044-4399-AE69-17BD457A2265}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DuplicateInjectsFromIncludedModuleFails", "IntegrationTests\DuplicateInjectsFromInIncludedModuleFails\DuplicateInjectsFromIncludedModuleFails.csproj", "{397FACB5-4857-446D-9B52-263F5D7CE12D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -208,6 +212,22 @@ Global
 		{F2B7A491-F65E-4E90-86FB-C3DA8C7E2F88}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F2B7A491-F65E-4E90-86FB-C3DA8C7E2F88}.Release|ARM.ActiveCfg = Release|Any CPU
 		{F2B7A491-F65E-4E90-86FB-C3DA8C7E2F88}.Release|x86.ActiveCfg = Release|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Release|ARM.ActiveCfg = Release|Any CPU
+		{47052838-D044-4399-AE69-17BD457A2265}.Release|x86.ActiveCfg = Release|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Release|ARM.ActiveCfg = Release|Any CPU
+		{397FACB5-4857-446D-9B52-263F5D7CE12D}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -220,6 +240,8 @@ Global
 		{0D2FE127-BDC3-44A8-BCD0-66A2A415CD32} = {D6076D93-CC12-40B4-B4E6-FBCCD520AB87}
 		{D63FFF2B-F39B-490D-973A-249E7BADF832} = {D6076D93-CC12-40B4-B4E6-FBCCD520AB87}
 		{F2B7A491-F65E-4E90-86FB-C3DA8C7E2F88} = {D6076D93-CC12-40B4-B4E6-FBCCD520AB87}
+		{47052838-D044-4399-AE69-17BD457A2265} = {D6076D93-CC12-40B4-B4E6-FBCCD520AB87}
+		{397FACB5-4857-446D-9B52-263F5D7CE12D} = {D6076D93-CC12-40B4-B4E6-FBCCD520AB87}
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true

--- a/Stiletto/Internal/Loaders/Reflection/ReflectionRuntimeModule.cs
+++ b/Stiletto/Internal/Loaders/Reflection/ReflectionRuntimeModule.cs
@@ -78,6 +78,13 @@ namespace Stiletto.Internal.Loaders.Reflection
 
         private void AddNewBinding(IDictionary<string, Binding> bindings, string key, MethodInfo method)
         {
+            if (bindings.ContainsKey(key))
+            {
+                throw new ArgumentException(
+                    string.Format("The module {0} provides the type {1} multiple times.",
+                                  ModuleType.FullName, key));
+            }
+
             bindings.Add(key, new ProviderMethodBinding(method, key, Module, IsLibrary));
         }
 


### PR DESCRIPTION
The compiler now catches duplicate types in Injects lists, both within individual modules and in the network of a complete module plus its inclusions.

The reflection fallback always threw on this error, but now provides a more descriptive error.
