### PR TITLE
P2: compile Lazy<T> and IProvider<T> bindings

### DIFF
--- a/src/Stiletto.Generator/InjectBindingGenerator.cs
+++ b/src/Stiletto.Generator/InjectBindingGenerator.cs
@@ -64,12 +64,14 @@ namespace Stiletto.Generator
                 return null;
             }
 
-            if (!TryBuildParams(ctor, out var parameters))
+            var wrappers = ImmutableArray.CreateBuilder<WrapperModel>();
+
+            if (!TryBuildParams(ctor, wrappers, out var parameters))
             {
                 return null;
             }
 
-            if (!TryBuildProperties(type, out var properties))
+            if (!TryBuildProperties(type, wrappers, out var properties))
             {
                 return null;
             }
@@ -102,15 +104,17 @@ namespace Stiletto.Generator
                 RequiredByCtor: reflectionName + "::.ctor",
                 Params: parameters,
                 Properties: properties,
-                BaseMemberKey: baseMemberKey);
+                BaseMemberKey: baseMemberKey,
+                Wrappers: wrappers.ToImmutable());
         }
 
-        private static bool TryBuildParams(IMethodSymbol ctor, out ImmutableArray<ParamModel> parameters)
+        private static bool TryBuildParams(IMethodSymbol ctor, ImmutableArray<WrapperModel>.Builder wrappers, out ImmutableArray<ParamModel> parameters)
         {
             var builder = ImmutableArray.CreateBuilder<ParamModel>(ctor.Parameters.Length);
             foreach (var p in ctor.Parameters)
             {
-                if (!RoslynKeys.TryKeyForType(p.Type, RoslynKeys.NamedQualifier(p), out var key))
+                var qualifier = RoslynKeys.NamedQualifier(p);
+                if (!RoslynKeys.TryKeyForType(p.Type, qualifier, out var key))
                 {
                     parameters = default;
                     return false;
@@ -119,13 +123,15 @@ namespace Stiletto.Generator
                 builder.Add(new ParamModel(
                     Key: key,
                     GlobalTypeName: p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+
+                AddWrapperIfAny(p.Type, qualifier, wrappers);
             }
 
             parameters = builder.MoveToImmutable();
             return true;
         }
 
-        private static bool TryBuildProperties(INamedTypeSymbol type, out ImmutableArray<PropertyModel> properties)
+        private static bool TryBuildProperties(INamedTypeSymbol type, ImmutableArray<WrapperModel>.Builder wrappers, out ImmutableArray<PropertyModel> properties)
         {
             var builder = ImmutableArray.CreateBuilder<PropertyModel>();
             var reflectionName = RoslynKeys.ReflectionName(type);
@@ -137,11 +143,13 @@ namespace Stiletto.Generator
                     continue;
                 }
 
+                var qualifier = RoslynKeys.NamedQualifier(prop);
+
                 // Needs an accessible, non-init instance setter and a keyable type.
                 if (prop.IsStatic
                     || prop.SetMethod is not { IsInitOnly: false } setter
                     || setter.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal)
-                    || !RoslynKeys.TryKeyForType(prop.Type, RoslynKeys.NamedQualifier(prop), out var key))
+                    || !RoslynKeys.TryKeyForType(prop.Type, qualifier, out var key))
                 {
                     properties = default;
                     return false;
@@ -152,6 +160,8 @@ namespace Stiletto.Generator
                     GlobalTypeName: prop.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                     PropertyName: prop.Name,
                     RequiredBy: reflectionName + "." + prop.Name));
+
+                AddWrapperIfAny(prop.Type, qualifier, wrappers);
             }
 
             properties = builder.ToImmutable();
@@ -231,6 +241,15 @@ namespace Stiletto.Generator
 
         private static bool IsNonGeneric(INamedTypeSymbol type)
             => type.Arity == 0 && !type.IsGenericType && !type.IsUnboundGenericType;
+
+        /// <summary>Records a Lazy/Provider wrapper if the dependency type is one.</summary>
+        internal static void AddWrapperIfAny(ITypeSymbol type, string? qualifier, ImmutableArray<WrapperModel>.Builder wrappers)
+        {
+            if (RoslynKeys.TryWrapper(type, qualifier, out var isProvider, out var delegateKey, out var elementGlobalName))
+            {
+                wrappers.Add(new WrapperModel(isProvider, delegateKey, elementGlobalName));
+            }
+        }
 
         private static bool HasInjectAttribute(ISymbol symbol)
             => symbol.GetAttributes().Any(a =>
@@ -426,5 +445,14 @@ namespace Stiletto.Generator
         string RequiredByCtor,
         EquatableArray<ParamModel> Params,
         EquatableArray<PropertyModel> Properties,
-        string? BaseMemberKey);
+        string? BaseMemberKey,
+        EquatableArray<WrapperModel> Wrappers);
+
+    /// <summary>
+    /// A <c>Lazy&lt;T&gt;</c> or <c>IProvider&lt;T&gt;</c> dependency discovered at an
+    /// injection point, which the aggregated loader turns into a <c>LazyBinding&lt;T&gt;</c>
+    /// / <c>ProviderBinding&lt;T&gt;</c>. <see cref="DelegateKey"/> is the switch label
+    /// (the key the resolver passes); <see cref="ElementGlobalTypeName"/> is <c>T</c>.
+    /// </summary>
+    internal sealed record WrapperModel(bool IsProvider, string DelegateKey, string ElementGlobalTypeName);
 }

--- a/src/Stiletto.Generator/ModuleGenerator.cs
+++ b/src/Stiletto.Generator/ModuleGenerator.cs
@@ -53,7 +53,8 @@ namespace Stiletto.Generator
                 return null;
             }
 
-            if (!TryBuildProviders(type, moduleReflectionName, out var providers))
+            var wrappers = ImmutableArray.CreateBuilder<WrapperModel>();
+            if (!TryBuildProviders(type, moduleReflectionName, wrappers, out var providers))
             {
                 return null;
             }
@@ -73,7 +74,8 @@ namespace Stiletto.Generator
                 IsOverride: isOverride,
                 InjectMemberKeys: injects,
                 IncludeGlobalTypeNames: includes,
-                Providers: providers);
+                Providers: providers,
+                Wrappers: wrappers.ToImmutable());
         }
 
         private static bool TryReadModuleAttribute(
@@ -144,7 +146,7 @@ namespace Stiletto.Generator
             return true;
         }
 
-        private static bool TryBuildProviders(INamedTypeSymbol type, string moduleReflectionName, out ImmutableArray<ProviderModel> providers)
+        private static bool TryBuildProviders(INamedTypeSymbol type, string moduleReflectionName, ImmutableArray<WrapperModel>.Builder wrappers, out ImmutableArray<ProviderModel> providers)
         {
             providers = default;
             var builder = ImmutableArray.CreateBuilder<ProviderModel>();
@@ -182,7 +184,8 @@ namespace Stiletto.Generator
                 var paramBuilder = ImmutableArray.CreateBuilder<ProviderParamModel>(method.Parameters.Length);
                 foreach (var p in method.Parameters)
                 {
-                    if (!RoslynKeys.TryKeyForType(p.Type, RoslynKeys.NamedQualifier(p), out var paramKey))
+                    var qualifier = RoslynKeys.NamedQualifier(p);
+                    if (!RoslynKeys.TryKeyForType(p.Type, qualifier, out var paramKey))
                     {
                         return false;
                     }
@@ -190,6 +193,8 @@ namespace Stiletto.Generator
                     paramBuilder.Add(new ProviderParamModel(
                         Key: paramKey,
                         GlobalTypeName: p.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+
+                    InjectBindingEmitter.AddWrapperIfAny(p.Type, qualifier, wrappers);
                 }
 
                 builder.Add(new ProviderModel(
@@ -207,16 +212,7 @@ namespace Stiletto.Generator
         }
 
         private static bool IsLazyOrProvider(ITypeSymbol type)
-        {
-            if (type is not INamedTypeSymbol { IsGenericType: true } named)
-            {
-                return false;
-            }
-
-            var ns = named.ContainingNamespace?.ToDisplayString();
-            return (named.MetadataName == "Lazy`1" && ns == "System")
-                || (named.MetadataName == "IProvider`1" && ns == "Stiletto");
-        }
+            => RoslynKeys.IsLazy(type) || RoslynKeys.IsProvider(type);
 
         internal static SourceText Emit(ModuleModel model)
         {
@@ -427,5 +423,6 @@ namespace Stiletto.Generator
         bool IsOverride,
         EquatableArray<string> InjectMemberKeys,
         EquatableArray<string> IncludeGlobalTypeNames,
-        EquatableArray<ProviderModel> Providers);
+        EquatableArray<ProviderModel> Providers,
+        EquatableArray<WrapperModel> Wrappers);
 }

--- a/src/Stiletto.Generator/RoslynKeys.cs
+++ b/src/Stiletto.Generator/RoslynKeys.cs
@@ -136,6 +136,45 @@ namespace Stiletto.Generator
             => symbol.GetAttributes().Any(a =>
                 a.AttributeClass?.ToDisplayString() == SingletonAttributeMetadataName);
 
+        public static bool IsLazy(ITypeSymbol type)
+            => type is INamedTypeSymbol { MetadataName: "Lazy`1", TypeArguments.Length: 1 } n
+               && n.ContainingNamespace?.ToDisplayString() == "System";
+
+        public static bool IsProvider(ITypeSymbol type)
+            => type is INamedTypeSymbol { MetadataName: "IProvider`1", TypeArguments.Length: 1 } n
+               && n.ContainingNamespace?.ToDisplayString() == "Stiletto";
+
+        /// <summary>
+        /// If <paramref name="type"/> is a <c>Lazy&lt;T&gt;</c> or
+        /// <c>IProvider&lt;T&gt;</c> whose element is keyable, produces the delegate
+        /// key the resolver will pass to the loader (qualifier-prefixed element key,
+        /// matching <c>Key.GetLazyKey</c>/<c>GetProviderKey</c>) and the element's
+        /// fully-qualified name for the generic binding instantiation.
+        /// </summary>
+        public static bool TryWrapper(ITypeSymbol type, string? qualifier, out bool isProvider, out string delegateKey, out string elementGlobalName)
+        {
+            isProvider = false;
+            delegateKey = string.Empty;
+            elementGlobalName = string.Empty;
+
+            var lazy = IsLazy(type);
+            var provider = IsProvider(type);
+            if (!lazy && !provider)
+            {
+                return false;
+            }
+
+            var element = ((INamedTypeSymbol)type).TypeArguments[0];
+            if (!TryKeyForType(element, qualifier, out delegateKey))
+            {
+                return false;
+            }
+
+            isProvider = provider;
+            elementGlobalName = element.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return true;
+        }
+
         /// <summary>
         /// The namespace-qualified, <c>+</c>-nested, backtick-arity name (no type
         /// arguments), e.g. <c>System.Collections.Generic.IList`1</c> — matching the

--- a/src/Stiletto.Generator/StilettoGenerator.cs
+++ b/src/Stiletto.Generator/StilettoGenerator.cs
@@ -127,9 +127,35 @@ namespace Stiletto.Generator
             sb.AppendLine("        }");
             sb.AppendLine();
 
-            // Lazy / IProvider are Phase 2 — fall through to the reflection fallback for now.
-            sb.AppendLine("        public global::Stiletto.Internal.Binding GetLazyInjectBinding(string key, object requiredBy, string lazyKey) => null!;");
-            sb.AppendLine("        public global::Stiletto.Internal.Binding GetIProviderInjectBinding(string key, object requiredBy, bool mustBeInjectable, string providerKey) => null!;");
+            // Lazy<T> / IProvider<T> dependencies discovered anywhere in the assembly
+            // become concrete LazyBinding<T> / ProviderBinding<T> instantiations.
+            var lazyCases = new List<WrapperModel>();
+            var providerCases = new List<WrapperModel>();
+            var lazySeen = new HashSet<string>();
+            var providerSeen = new HashSet<string>();
+            foreach (var model in injectModels)
+            {
+                CollectWrappers(model.Wrappers, lazyCases, providerCases, lazySeen, providerSeen);
+            }
+            foreach (var model in moduleModels)
+            {
+                CollectWrappers(model.Wrappers, lazyCases, providerCases, lazySeen, providerSeen);
+            }
+
+            EmitWrapperMethod(
+                sb,
+                "public global::Stiletto.Internal.Binding GetLazyInjectBinding(string key, object requiredBy, string lazyKey)",
+                switchVar: "lazyKey",
+                cases: lazyCases,
+                buildCase: w => "new global::Stiletto.Internal.Loaders.Codegen.LazyBinding<" + w.ElementGlobalTypeName + ">(key, requiredBy, lazyKey)");
+
+            EmitWrapperMethod(
+                sb,
+                "public global::Stiletto.Internal.Binding GetIProviderInjectBinding(string key, object requiredBy, bool mustBeInjectable, string providerKey)",
+                switchVar: "providerKey",
+                cases: providerCases,
+                buildCase: w => "new global::Stiletto.Internal.Loaders.Codegen.ProviderBinding<" + w.ElementGlobalTypeName + ">(key, requiredBy, mustBeInjectable, providerKey)");
+
             sb.AppendLine("    }");
             sb.AppendLine();
 
@@ -142,6 +168,54 @@ namespace Stiletto.Generator
             sb.AppendLine("}");
 
             spc.AddSource("Stiletto.Generated.CompiledLoader.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+        }
+
+        private static void CollectWrappers(
+            EquatableArray<WrapperModel> wrappers,
+            List<WrapperModel> lazyCases,
+            List<WrapperModel> providerCases,
+            HashSet<string> lazySeen,
+            HashSet<string> providerSeen)
+        {
+            foreach (var w in wrappers)
+            {
+                if (w.IsProvider)
+                {
+                    if (providerSeen.Add(w.DelegateKey)) providerCases.Add(w);
+                }
+                else
+                {
+                    if (lazySeen.Add(w.DelegateKey)) lazyCases.Add(w);
+                }
+            }
+        }
+
+        private static void EmitWrapperMethod(
+            StringBuilder sb,
+            string signature,
+            string switchVar,
+            List<WrapperModel> cases,
+            System.Func<WrapperModel, string> buildCase)
+        {
+            if (cases.Count == 0)
+            {
+                // No such wrappers here — defer to the reflection fallback.
+                sb.Append("        ").Append(signature).AppendLine(" => null!;");
+                return;
+            }
+
+            sb.Append("        ").AppendLine(signature);
+            sb.AppendLine("        {");
+            sb.Append("            switch (").Append(switchVar).AppendLine(")");
+            sb.AppendLine("            {");
+            foreach (var w in cases)
+            {
+                sb.Append("                case ").Append(Literal(w.DelegateKey)).Append(": return ")
+                  .Append(buildCase(w)).AppendLine(";");
+            }
+            sb.AppendLine("                default: return null!;");
+            sb.AppendLine("            }");
+            sb.AppendLine("        }");
         }
 
         private static string GlobalName(string? ns, string typeName)

--- a/src/Stiletto/Internal/Loaders/Codegen/WrapperBindings.cs
+++ b/src/Stiletto/Internal/Loaders/Codegen/WrapperBindings.cs
@@ -1,0 +1,109 @@
+/*
+ * Copyright © Ben Bader
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace Stiletto.Internal.Loaders.Codegen
+{
+    /// <summary>
+    /// A compiled <see cref="Lazy{T}"/> binding. Equivalent to the reflection
+    /// loader's <c>ReflectionLazyBinding</c>, but without the runtime
+    /// <c>MakeGenericType</c>/<c>Activator</c> dance — the generator instantiates
+    /// this with a concrete <typeparamref name="T"/>, so it is AOT-safe.
+    /// </summary>
+    public sealed class LazyBinding<T> : Binding
+    {
+        private readonly string lazyKey;
+        private Binding delegateBinding = null!;
+        private Lazy<T>? lazy;
+
+        public LazyBinding(string key, object requiredBy, string lazyKey)
+            : base(key, null, false, requiredBy)
+        {
+            this.lazyKey = lazyKey;
+        }
+
+        public override void Resolve(Resolver resolver)
+        {
+            delegateBinding = resolver.RequestBinding(lazyKey, RequiredBy);
+        }
+
+        public override object Get()
+        {
+            return lazy ??= new Lazy<T>(() => (T)delegateBinding.Get());
+        }
+
+        public override void InjectProperties(object target)
+        {
+            throw new NotSupportedException("Lazy property injection is not supported.");
+        }
+    }
+
+    /// <summary>
+    /// A compiled <see cref="IProvider{T}"/> binding — the AOT-safe counterpart of
+    /// the reflection loader's <c>ReflectionProviderBinding</c>.
+    /// </summary>
+    public sealed class ProviderBinding<T> : Binding
+    {
+        private readonly bool mustBeInjectable;
+        private readonly string delegateKey;
+        private Binding inner = null!;
+        private IProvider<T>? impl;
+
+        public ProviderBinding(string key, object requiredBy, bool mustBeInjectable, string delegateKey)
+            : base(key, null, false, requiredBy)
+        {
+            this.mustBeInjectable = mustBeInjectable;
+            this.delegateKey = delegateKey;
+        }
+
+        public override void Resolve(Resolver resolver)
+        {
+            inner = resolver.RequestBinding(delegateKey, RequiredBy, mustBeInjectable);
+        }
+
+        public override void GetDependencies(ISet<Binding> injectDependencies, ISet<Binding> propertyDependencies)
+        {
+            inner.GetDependencies(injectDependencies, propertyDependencies);
+        }
+
+        public override void InjectProperties(object target)
+        {
+            inner.InjectProperties(target);
+        }
+
+        public override object Get()
+        {
+            return impl ??= new Impl(inner);
+        }
+
+        private sealed class Impl : IProvider<T>
+        {
+            private readonly Binding binding;
+
+            public Impl(Binding binding)
+            {
+                this.binding = binding;
+            }
+
+            public T Get()
+            {
+                return (T)binding.Get();
+            }
+        }
+    }
+}

--- a/test/Stiletto.Generator.Tests/ContainerIntegrationTests.cs
+++ b/test/Stiletto.Generator.Tests/ContainerIntegrationTests.cs
@@ -178,6 +178,62 @@ namespace Stiletto.Generator.Tests
             Assert.NotNull(get.Invoke(container, null));
         }
 
+        private const string WrapperSource = """
+            using System;
+            using Stiletto;
+
+            namespace WrapperSample
+            {
+                public class Leaf { [Inject] public Leaf() { } }
+
+                public class Consumer
+                {
+                    public Lazy<Leaf> LazyLeaf;
+                    public IProvider<Leaf> LeafProvider;
+
+                    [Inject] public Consumer(Lazy<Leaf> lazyLeaf, IProvider<Leaf> leafProvider)
+                    {
+                        LazyLeaf = lazyLeaf;
+                        LeafProvider = leafProvider;
+                    }
+                }
+
+                [Module(Injects = new[] { typeof(Consumer) })]
+                public class WrapperModule { }
+            }
+            """;
+
+        [Fact]
+        public void LazyAndProviderResolveThroughCompiledBindings()
+        {
+            var assembly = CompileAndLoad(WrapperSource, "StilettoWrapperSample");
+
+            // The compiled loader (with the Lazy/Provider switches) self-registers.
+            System.Runtime.CompilerServices.RuntimeHelpers.RunModuleConstructor(assembly.ManifestModule.ModuleHandle);
+            Assert.Contains(
+                Stiletto.LoaderRegistry.Snapshot(),
+                l => l.GetType().Assembly == assembly && l.GetType().Name == "CompiledLoader");
+
+            var container = Stiletto.Container.Create(assembly.GetType("WrapperSample.WrapperModule")!);
+            var consumerType = assembly.GetType("WrapperSample.Consumer")!;
+            var get = typeof(Stiletto.Container).GetMethod("Get")!.MakeGenericMethod(consumerType);
+            var consumer = get.Invoke(container, null)!;
+
+            var leafType = assembly.GetType("WrapperSample.Leaf")!;
+
+            // Lazy<Leaf>: the compiled binding produced a real System.Lazy<Leaf>.
+            dynamic lazy = consumerType.GetField("LazyLeaf")!.GetValue(consumer)!;
+            Assert.False((bool)lazy.IsValueCreated);      // deferred
+            object leafFromLazy = lazy.Value;
+            Assert.True((bool)lazy.IsValueCreated);
+            Assert.IsType(leafType, leafFromLazy);
+
+            // IProvider<Leaf>: .Get() yields instances of Leaf. Reached via the
+            // covariant public interface (the concrete impl is a private nested type).
+            var provider = (Stiletto.IProvider<object>)consumerType.GetField("LeafProvider")!.GetValue(consumer)!;
+            Assert.IsType(leafType, provider.Get());
+        }
+
         private static Assembly CompileAndLoad(string source, string assemblyName)
         {
             var references = AppDomain.CurrentDomain.GetAssemblies()

--- a/test/Stiletto.Generator.Tests/InjectBindingGeneratorTests.GenericDependencyIsInjected#Stiletto.Generated.CompiledLoader.g.verified.cs
+++ b/test/Stiletto.Generator.Tests/InjectBindingGeneratorTests.GenericDependencyIsInjected#Stiletto.Generated.CompiledLoader.g.verified.cs
@@ -25,8 +25,22 @@ namespace Stiletto.Generated
             }
         }
 
-        public global::Stiletto.Internal.Binding GetLazyInjectBinding(string key, object requiredBy, string lazyKey) => null!;
-        public global::Stiletto.Internal.Binding GetIProviderInjectBinding(string key, object requiredBy, bool mustBeInjectable, string providerKey) => null!;
+        public global::Stiletto.Internal.Binding GetLazyInjectBinding(string key, object requiredBy, string lazyKey)
+        {
+            switch (lazyKey)
+            {
+                case "Sample.Bean": return new global::Stiletto.Internal.Loaders.Codegen.LazyBinding<global::Sample.Bean>(key, requiredBy, lazyKey);
+                default: return null!;
+            }
+        }
+        public global::Stiletto.Internal.Binding GetIProviderInjectBinding(string key, object requiredBy, bool mustBeInjectable, string providerKey)
+        {
+            switch (providerKey)
+            {
+                case "Sample.Bean": return new global::Stiletto.Internal.Loaders.Codegen.ProviderBinding<global::Sample.Bean>(key, requiredBy, mustBeInjectable, providerKey);
+                default: return null!;
+            }
+        }
     }
 
     [global::System.Runtime.CompilerServices.CompilerGenerated]


### PR DESCRIPTION
Removes the last reflection from the resolved object graph. Previously Lazy<T> and IProvider<T> dependencies fell through to the reflection fallback (ReflectionLazyBinding / ReflectionProviderBinding, which use MakeGenericType + Activator); the aggregated loader returned null for them.

Runtime: adds AOT-safe generics LazyBinding<T> / ProviderBinding<T> in Stiletto.Internal.Loaders.Codegen, semantically matched to their reflection counterparts (LazyBinding reports no dependency, for cycle-breaking; both cache their produced Lazy<T> / IProvider<T>).

Generator: discovers Lazy<T> / IProvider<T> at inject constructor params, inject properties, and module provider params, and emits switch cases in the loader's GetLazyInjectBinding / GetIProviderInjectBinding (new LazyBinding<Foo>(...) / ProviderBinding<Foo>(...)) with a concrete element type. Emits the null! one-liner when there are none, so only graphs that use wrappers change.

Inject-binding emission is unchanged — a Lazy<Foo> param was already an ordinary generic dependency; only the loader's wrapper switches are new.

New end-to-end test resolves a deferred Lazy<Leaf> and an IProvider<Leaf> through a live Container via the compiled loader. 46 tests green.