### PR TITLE
P3: NativeAOT / trimming support via a reflection-fallback feature sw…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,26 @@ jobs:
 
       - name: Test
         run: dotnet test Stiletto.slnx --configuration Release --no-build
+
+  aot-smoke:
+    name: NativeAOT smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Install NativeAOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      # Publishes the sample with the reflection fallback switched off, so the
+      # trimmer/AOT must remove the reflection loaders entirely. A stray IL warning
+      # or a runtime that needed reflection would fail the publish or the run.
+      - name: Publish (NativeAOT, registry-only)
+        run: dotnet publish samples/Stiletto.AotSmokeTest/Stiletto.AotSmokeTest.csproj -c Release -r linux-x64
+
+      - name: Run the native binary
+        run: samples/Stiletto.AotSmokeTest/bin/Release/net10.0/linux-x64/native/Stiletto.AotSmokeTest

--- a/Stiletto.slnx
+++ b/Stiletto.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/samples/">
+    <Project Path="samples/Stiletto.AotSmokeTest/Stiletto.AotSmokeTest.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Stiletto.Generator/Stiletto.Generator.csproj" />
     <Project Path="src/Stiletto/Stiletto.csproj" />

--- a/samples/Stiletto.AotSmokeTest/CoffeeGraph.cs
+++ b/samples/Stiletto.AotSmokeTest/CoffeeGraph.cs
@@ -1,0 +1,32 @@
+using Stiletto;
+
+namespace AotSmoke
+{
+    [Singleton]
+    public class Heater
+    {
+        [Inject] public Heater() { }
+    }
+
+    public class Pump
+    {
+        public readonly Heater Heater;
+
+        [Inject] public Pump(Heater heater) { Heater = heater; }
+    }
+
+    public class CoffeeMaker
+    {
+        public readonly Pump Pump;
+
+        [Inject] public CoffeeMaker(Pump pump) { Pump = pump; }
+
+        [Inject, Named("brand")] public string Brand { get; set; }
+    }
+
+    [Module(Injects = new[] { typeof(CoffeeMaker) })]
+    public class CoffeeModule
+    {
+        [Provides, Named("brand")] public string Brand() => "Stiletto";
+    }
+}

--- a/samples/Stiletto.AotSmokeTest/Program.cs
+++ b/samples/Stiletto.AotSmokeTest/Program.cs
@@ -1,0 +1,22 @@
+using System;
+using AotSmoke;
+using Stiletto;
+
+// Fails loudly if the reflection fallback is somehow still engaged.
+if (Container.ReflectionFallbackEnabled)
+{
+    Console.Error.WriteLine("FAIL: reflection fallback is enabled; expected registry-only.");
+    return 2;
+}
+
+var container = Container.Create(typeof(CoffeeModule));
+var maker = container.Get<CoffeeMaker>();
+
+if (maker.Pump?.Heater is null || maker.Brand != "Stiletto")
+{
+    Console.Error.WriteLine("FAIL: object graph not wired correctly.");
+    return 1;
+}
+
+Console.WriteLine($"OK: resolved {maker.Brand} CoffeeMaker with {maker.Pump.Heater.GetType().Name} (registry-only, no reflection).");
+return 0;

--- a/samples/Stiletto.AotSmokeTest/Stiletto.AotSmokeTest.csproj
+++ b/samples/Stiletto.AotSmokeTest/Stiletto.AotSmokeTest.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <Nullable>annotations</Nullable>
+    <IsPackable>false</IsPackable>
+
+    <!-- Turns on the trim/AOT analyzers at build time and NativeAOT at publish time. -->
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <!-- Registry-only: disable the reflection fallback so the trimmer/AOT removes it
+       entirely. Trim="true" makes the value a trim-time constant. -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Stiletto.ReflectionFallback" Value="false" Trim="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Stiletto\Stiletto.csproj" />
+    <ProjectReference Include="..\..\src\Stiletto.Generator\Stiletto.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Stiletto/Container.cs
+++ b/src/Stiletto/Container.cs
@@ -27,11 +27,31 @@ namespace Stiletto
 {
     public abstract class Container
     {
+        internal const string ReflectionFallbackSwitch = "Stiletto.ReflectionFallback";
+
         public abstract Container Add(params object[] modules);
         public abstract T Get<T>();
         public abstract T Inject<T>(T instance);
         public abstract object Inject(object instance, Type type);
         public abstract void Validate();
+
+        /// <summary>
+        /// Whether the reflection fallback (reflection-by-name discovery plus pure
+        /// reflection bindings) is consulted for anything the source generator did not
+        /// compile. Defaults to <see langword="true"/>. Set the
+        /// <c>Stiletto.ReflectionFallback</c> feature switch (e.g. via
+        /// <c>&lt;RuntimeHostConfigurationOption&gt;</c>) to <see langword="false"/> for
+        /// a registry-only container: faster, and — under trimming/NativeAOT — the
+        /// reflection code is removed entirely and missing bindings fail loudly rather
+        /// than silently reflecting.
+        /// </summary>
+#if NET
+        [System.Diagnostics.CodeAnalysis.FeatureSwitchDefinition(ReflectionFallbackSwitch)]
+        [System.Diagnostics.CodeAnalysis.FeatureGuard(typeof(System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute))]
+        [System.Diagnostics.CodeAnalysis.FeatureGuard(typeof(System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute))]
+#endif
+        public static bool ReflectionFallbackEnabled
+            => !AppContext.TryGetSwitch(ReflectionFallbackSwitch, out var enabled) || enabled;
 
         /// <summary>
         /// Creates a container with the given modules, of which at least one
@@ -49,14 +69,13 @@ namespace Stiletto
         public static Container Create(params object[] modules)
         {
             // Source-generated loaders self-register via [ModuleInitializer]; consult
-            // them first, then fall back to reflection-by-name (CodegenLoader) and pure
-            // reflection for anything not compiled. The fallback keeps behavior a strict
-            // superset of the old AppDomain-scanning path.
-            var loaders = new List<ILoader>(LoaderRegistry.Snapshot())
+            // them first, then optionally fall back to reflection for anything not
+            // compiled (see ReflectionFallbackEnabled).
+            var loaders = new List<ILoader>(LoaderRegistry.Snapshot());
+            if (ReflectionFallbackEnabled)
             {
-                new CodegenLoader(),
-                new ReflectionLoader(),
-            };
+                AddReflectionFallback(loaders);
+            }
 
             var loader = new RuntimeAggregationLoader(loaders.ToArray());
             return StilettoContainer.MakeContainer(null, loader, modules);
@@ -66,9 +85,23 @@ namespace Stiletto
         {
             var allLoaders = new List<ILoader>(loaders);
             allLoaders.AddRange(LoaderRegistry.Snapshot());
-            allLoaders.Add(new CodegenLoader());
-            allLoaders.Add(new ReflectionLoader());
+            if (ReflectionFallbackEnabled)
+            {
+                AddReflectionFallback(allLoaders);
+            }
             return StilettoContainer.MakeContainer(null, new RuntimeAggregationLoader(allLoaders.ToArray()), modules);
+        }
+
+#if NET
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode(
+            "The reflection fallback discovers compiled bindings by name and builds reflection bindings; disable it with the Stiletto.ReflectionFallback feature switch under trimming/AOT.")]
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode(
+            "Reflection bindings construct types and generic instantiations at runtime.")]
+#endif
+        private static void AddReflectionFallback(List<ILoader> loaders)
+        {
+            loaders.Add(new CodegenLoader());
+            loaders.Add(new ReflectionLoader());
         }
 
         private class StilettoContainer : Container

--- a/test/Stiletto.Tests/ReflectionFallbackTests.cs
+++ b/test/Stiletto.Tests/ReflectionFallbackTests.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Stiletto.Tests
+{
+    public class ReflectionFallbackTests
+    {
+        [Fact]
+        public void DefaultsToEnabled()
+        {
+            // Unless the Stiletto.ReflectionFallback switch is set off, reflection
+            // remains available — so behavior stays a superset of the pre-P3 default.
+            // (The switch-off path is proven end-to-end by the NativeAOT smoke test.)
+            Assert.True(Container.ReflectionFallbackEnabled);
+        }
+    }
+}


### PR DESCRIPTION
…itch

Adds Container.ReflectionFallbackEnabled, backed by the Stiletto.ReflectionFallback feature switch (default on). When off, Container.Create is registry-only: the reflection loaders (CodegenLoader + ReflectionLoader) are not consulted, so under trimming/NativeAOT they're removed entirely and a missing binding fails loudly instead of silently reflecting.

The switch is annotated with [FeatureSwitchDefinition] + [FeatureGuard] (net-only), so the trimmer folds it to a constant and the analyzer treats the RequiresDynamicCode/ RequiresUnreferencedCode fallback as unreachable when it's off — no manual ILLink.Substitutions.xml needed. The fallback-adding helper carries the Requires* annotations.

samples/Stiletto.AotSmokeTest is a NativeAOT console app (PublishAot, fallback off via RuntimeHostConfigurationOption) that resolves a graph and exits non-zero on failure. Verified locally: publishes to a native arm64 binary with zero IL trim/AOT warnings and runs registry-only. A new CI job publishes it for linux-x64 and runs the binary as a hard gate.

47 tests green; runtime multitargets net10.0;netstandard2.0 (annotations #if NET).