### PR TITLE
fix: don't misclassify keys that merely nest Provider/Lazy/Set

### DIFF
--- a/src/Stiletto/Key.cs
+++ b/src/Stiletto/Key.cs
@@ -234,7 +234,12 @@ namespace Stiletto
 
         private static bool SubstringStartsWith(string str, int offset, string substring)
         {
-            return str.IndexOf(substring, offset, Comparison) >= 0;
+            // Must match *at* offset, not merely somewhere at-or-after it: callers
+            // (GetProviderKey/GetLazyKey/GetSetElementKey) hand the result to
+            // ExtractKey, whose slicing assumes the prefix begins exactly at offset.
+            // Using >= 0 misclassified keys that only *contain* the prefix as a
+            // nested generic argument, e.g. List<IProvider<int>>.
+            return str.IndexOf(substring, offset, Comparison) == offset;
         }
     }
 }

--- a/test/Stiletto.Tests/KeyTests.cs
+++ b/test/Stiletto.Tests/KeyTests.cs
@@ -1,0 +1,42 @@
+using Xunit;
+
+namespace Stiletto.Tests
+{
+    public class KeyTests
+    {
+        [Fact]
+        public void GetProviderKey_ExtractsProvidedType_ForAProviderKey()
+        {
+            var providerKey = Key.Get(typeof(IProvider<int>))!;
+
+            Assert.Equal(Key.Get(typeof(int)), Key.GetProviderKey(providerKey));
+        }
+
+        [Fact]
+        public void GetLazyKey_ExtractsLazyType_ForALazyKey()
+        {
+            var lazyKey = Key.Get(typeof(Lazy<int>))!;
+
+            Assert.Equal(Key.Get(typeof(int)), Key.GetLazyKey(lazyKey));
+        }
+
+        [Fact]
+        public void GetProviderKey_ReturnsNull_WhenProviderIsOnlyANestedTypeArgument()
+        {
+            // List<IProvider<int>> merely *contains* the provider prefix as a nested
+            // generic argument; its key does not *start* with it, so it is not a
+            // provider binding.
+            var key = Key.Get(typeof(List<IProvider<int>>))!;
+
+            Assert.Null(Key.GetProviderKey(key));
+        }
+
+        [Fact]
+        public void GetLazyKey_ReturnsNull_WhenLazyIsOnlyANestedTypeArgument()
+        {
+            var key = Key.Get(typeof(List<Lazy<int>>))!;
+
+            Assert.Null(Key.GetLazyKey(key));
+        }
+    }
+}


### PR DESCRIPTION
Key.SubstringStartsWith used IndexOf(...) >= 0, which is true when the prefix appears anywhere at or after the offset - not only when the type *starts* with it. Its callers (GetProviderKey/GetLazyKey/GetSetElementKey) then hand the match to ExtractKey, whose slicing assumes the prefix begins exactly at the offset, so a key like List<IProvider<int>> was treated as a provider binding and sliced into garbage instead of returning null.

Match at the offset (== offset) so only an outermost wrapper is detected. Add KeyTests covering the extract-happy-path and the nested-argument cases.