### PR TITLE
test: port lazy/provider/set/validator + cross-assembly tests to the new layout

### DIFF
--- a/Stiletto.slnx
+++ b/Stiletto.slnx
@@ -8,6 +8,7 @@
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/Stiletto.Generator.Tests/Stiletto.Generator.Tests.csproj" />
+    <Project Path="test/Stiletto.Integration.External/Stiletto.Integration.External.csproj" />
     <Project Path="test/Stiletto.Integration.Tests/Stiletto.Integration.Tests.csproj" />
     <Project Path="test/Stiletto.Tests/Stiletto.Tests.csproj" />
   </Folder>

--- a/test/Stiletto.Integration.External/Stiletto.Integration.External.csproj
+++ b/test/Stiletto.Integration.External/Stiletto.Integration.External.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    A companion assembly for the cross-assembly integration test. Like the main
+    integration project, it references Stiletto.Generator as an analyzer so csc
+    runs the generator during THIS assembly's build: it gets its own compiled
+    bindings and its own self-registering CompiledLoader. The point is to prove
+    that a binding compiled here resolves when the *module* lives in a different
+    assembly — i.e. that per-assembly CompiledLoaders aggregate at runtime.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- DI sample types are populated by injection; don't warn about it. -->
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Stiletto\Stiletto.csproj" />
+    <ProjectReference Include="..\..\src\Stiletto.Generator\Stiletto.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/test/Stiletto.Integration.External/Widget.cs
+++ b/test/Stiletto.Integration.External/Widget.cs
@@ -1,0 +1,22 @@
+using Stiletto;
+
+namespace Stiletto.Integration.External
+{
+    // An injectable whose [Inject] constructor pulls dependencies that only a
+    // module in *another* assembly provides. The generator compiles a binding for
+    // this type into THIS assembly; the module that supplies string/int lives in
+    // Stiletto.Integration.Tests. Resolving it therefore only works if both
+    // assemblies' compiled loaders are aggregated at runtime.
+    public class Widget
+    {
+        public readonly string Name;
+        public readonly int Count;
+
+        [Inject]
+        public Widget(string name, int count)
+        {
+            Name = name;
+            Count = count;
+        }
+    }
+}

--- a/test/Stiletto.Integration.Tests/CrossAssemblyTests.cs
+++ b/test/Stiletto.Integration.Tests/CrossAssemblyTests.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using Stiletto;
+using Stiletto.Integration.External;
+using Xunit;
+
+namespace Stiletto.Integration.Tests
+{
+    /// <summary>
+    /// Ports the old <c>CanInjectCrossAssemblies</c> integration test to the source
+    /// generator world. The injectable (<see cref="Widget"/>) is compiled — with its
+    /// own binding and self-registering loader — into a *different* assembly than the
+    /// module that provides its dependencies. Resolving it exercises the runtime's
+    /// aggregation of per-assembly <c>CompiledLoader</c>s.
+    /// </summary>
+    public class CrossAssemblyTests
+    {
+        [Fact]
+        public void GeneratorRanInTheExternalAssembly_AndEmittedItsBinding()
+        {
+            var externalAssembly = typeof(Widget).Assembly;
+
+            // The generator ran during the external assembly's own build, so its
+            // compiled binding and aggregated loader live there — not in this project.
+            Assert.NotNull(externalAssembly.GetType("Stiletto.Integration.External.Widget_CompiledBinding"));
+            Assert.NotNull(externalAssembly.GetType("Stiletto.Generated.CompiledLoader"));
+        }
+
+        [Fact]
+        public void CompiledBindingFromAnotherAssembly_ResolvesThroughAggregatedLoaders()
+        {
+            // Touching a type from the external assembly forces it to load, which fires
+            // its [ModuleInitializer] and registers its CompiledLoader.
+            var externalAssembly = typeof(Widget).Assembly;
+
+            Assert.Contains(
+                LoaderRegistry.Snapshot(),
+                loader => loader.GetType().Assembly == externalAssembly
+                          && loader.GetType().Name == "CompiledLoader");
+
+            // The module lives here; the injectable's compiled binding lives in the
+            // external assembly. Resolution succeeds only if both loaders participate.
+            var container = Container.Create(typeof(WidgetModule));
+            var widget = container.Get<Widget>();
+
+            Assert.NotNull(widget);
+            Assert.Equal("gadget", widget.Name);
+            Assert.Equal(42, widget.Count);
+        }
+
+        [Module(Injects = new[] { typeof(Widget) })]
+        public class WidgetModule
+        {
+            [Provides] public string Name() => "gadget";
+            [Provides] public int Count() => 42;
+        }
+    }
+}

--- a/test/Stiletto.Integration.Tests/GeneratedGraphValidationTests.cs
+++ b/test/Stiletto.Integration.Tests/GeneratedGraphValidationTests.cs
@@ -1,0 +1,89 @@
+using Stiletto;
+using Xunit;
+
+namespace Stiletto.Integration.Tests
+{
+    /// <summary>
+    /// Ports the old build-failure integration tests (CircularDependenciesFail,
+    /// UnusedBindingsFail, DuplicateInjectsTypesFail). Under the Fody weaver those
+    /// were compile-time errors; the source generator instead always emits bindings
+    /// and leaves graph validation to the runtime. These types are compiled by the
+    /// generator in this assembly, so the tests prove the *generated* bindings feed
+    /// the runtime cycle/orphan/duplicate checks exactly as the woven ones did.
+    /// </summary>
+    public class GeneratedGraphValidationTests
+    {
+        [Fact]
+        public void CircularDependencies_AreDetected_AtValidation()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(CircularModule)).Validate());
+        }
+
+        [Fact]
+        public void UnusedProviderMethods_AreDetected_AtValidation()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(UnusedBindingsModule)).Validate());
+        }
+
+        [Fact]
+        public void DuplicateInjectTypes_AreRejected_WhenBuildingTheContainer()
+        {
+            Assert.Throws<ArgumentException>(
+                () => Container.Create(typeof(DuplicateInjectsModule)));
+        }
+
+        // --- Circular: Foo <-> Bar (property injection) plus a ctor that needs both. ---
+
+        public class Foo
+        {
+            [Inject] public Bar Bar { get; set; }
+        }
+
+        public class Bar
+        {
+            [Inject] public Foo Foo { get; set; }
+        }
+
+        public class Foobar
+        {
+            [Inject]
+            public Foobar(Foo foo, Bar bar)
+            {
+            }
+        }
+
+        [Module(Injects = new[] { typeof(Foobar) })]
+        public class CircularModule
+        {
+        }
+
+        // --- Unused: ProvideObject is never depended upon by the injected graph. ---
+
+        public class NeedsAString
+        {
+            [Inject] public string Foo { get; set; }
+        }
+
+        [Module(Injects = new[] { typeof(NeedsAString) })]
+        public class UnusedBindingsModule
+        {
+            [Provides] public string ProvideString() => "foo";
+            [Provides] public object ProvideObject() => new object();
+        }
+
+        // --- Duplicate: the same type listed twice in a module's Injects. ---
+
+        public class InjectableClass
+        {
+            [Inject] public string Foo { get; set; }
+        }
+
+        [Module(Injects = new[] { typeof(InjectableClass), typeof(InjectableClass) })]
+        public class DuplicateInjectsModule
+        {
+            [Provides] public string ProvideString() => "foo";
+        }
+    }
+}

--- a/test/Stiletto.Integration.Tests/Stiletto.Integration.Tests.csproj
+++ b/test/Stiletto.Integration.Tests/Stiletto.Integration.Tests.csproj
@@ -24,6 +24,9 @@
     <ProjectReference Include="..\..\src\Stiletto.Generator\Stiletto.Generator.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
+    <!-- A second assembly with its own generated bindings + loader, for the
+         cross-assembly resolution test. -->
+    <ProjectReference Include="..\Stiletto.Integration.External\Stiletto.Integration.External.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Stiletto.Tests/KeyTests.cs
+++ b/test/Stiletto.Tests/KeyTests.cs
@@ -38,5 +38,76 @@ namespace Stiletto.Tests
 
             Assert.Null(Key.GetLazyKey(key));
         }
+
+        [Fact]
+        public void SimpleTypes_EqualReflectionFullName()
+        {
+            Assert.Equal("System.String", Key.Get(typeof(string)));
+            Assert.Equal("System.Int32", Key.Get(typeof(int)));
+            Assert.Equal("System.Collections.IList", Key.Get(typeof(System.Collections.IList)));
+        }
+
+        [Fact]
+        public void MemberKeys_OfSimpleTypes_EqualPrefixPlusReflectionFullName()
+        {
+            Assert.Equal("members/System.String", Key.GetMemberKey<string>());
+            Assert.Equal("members/System.Int32", Key.GetMemberKey<int>());
+            Assert.Equal("members/System.Collections.IList", Key.GetMemberKey<System.Collections.IList>());
+        }
+
+        [Fact]
+        public void NamedKeys_OfSimpleTypes_EqualNamePlusReflectionFullName()
+        {
+            Assert.Equal("@foo/System.String", Key.Get(typeof(string), "foo"));
+            Assert.Equal("@bar/System.Int32", Key.Get(typeof(int), "bar"));
+            Assert.Equal("@baz/System.Collections.IList", Key.Get(typeof(System.Collections.IList), "baz"));
+        }
+
+        [Fact]
+        public void Arrays_EqualReflectionFullNamePlusRankedSuffix()
+        {
+            Assert.Equal("System.Int32[]", Key.Get(typeof(int[])));
+            Assert.Equal("System.Object[,,]", Key.Get(typeof(object[,,])));
+            // Note the brackets really are transposed: the C# declaration decimal[,][]
+            // is a 2D array of decimal arrays, not the other way around.
+            Assert.Equal("System.Decimal[][,]", Key.Get(typeof(decimal[,][])));
+        }
+
+        [Fact]
+        public void Generics_LookLikeCSharpGenerics()
+        {
+            Assert.Equal(
+                "System.Collections.Generic.List`1<System.Int32>",
+                Key.Get(typeof(List<int>)));
+            Assert.Equal(
+                "System.Collections.Generic.IDictionary`2<System.String,System.Object>",
+                Key.Get(typeof(IDictionary<string, object>)));
+        }
+
+        [Fact]
+        public void ProviderKeys_CanHaveProvidedTypeExtracted()
+        {
+            var providedTypeKey = Key.GetProviderKey(Key.Get(typeof(IProvider<int>))!);
+            Assert.NotNull(providedTypeKey);
+            Assert.Equal("System.Int32", providedTypeKey);
+        }
+
+        [Fact]
+        public void LazyKeys_CanHaveLazyTypeExtracted()
+        {
+            var lazyTypeKey = Key.GetLazyKey(Key.Get(typeof(Lazy<object>))!);
+            Assert.Equal("System.Object", lazyTypeKey);
+        }
+
+        [Fact]
+        public void NamedKeys_CanBeDetected()
+        {
+            var namedKey = Key.Get(typeof(object), "foo")!;
+            var anonymousKey = Key.Get(typeof(object))!;
+
+            Assert.NotEqual(anonymousKey, namedKey);
+            Assert.True(Key.IsNamed(namedKey));
+            Assert.False(Key.IsNamed(anonymousKey));
+        }
     }
 }

--- a/test/Stiletto.Tests/LazyInjectionTests.cs
+++ b/test/Stiletto.Tests/LazyInjectionTests.cs
@@ -1,0 +1,49 @@
+using Xunit;
+
+namespace Stiletto.Tests
+{
+    public class LazyInjectionTests
+    {
+        [Fact]
+        public void CanMakeProvidedObjectLazy()
+        {
+            var container = Container.Create(typeof(NonLazyModule));
+            var greedy = container.Get<NeedsAnExpensiveObject>();
+            Assert.NotNull(greedy.Expensive);
+        }
+
+        [Fact]
+        public void LazyValue_IsProduced_WhenForced()
+        {
+            var container = Container.Create(typeof(NonLazyModule));
+            var greedy = container.Get<NeedsAnExpensiveObject>();
+            Assert.Equal("an expensive web service call", greedy.Expensive.Value);
+        }
+
+        [Module(Injects = new[] { typeof(NeedsAnExpensiveObject) })]
+        public class NonLazyModule
+        {
+            [Provides]
+            public string SomeExpensiveObject()
+            {
+                return "an expensive web service call";
+            }
+        }
+
+        public class NeedsAnExpensiveObject
+        {
+            private readonly Lazy<string> expensive;
+
+            public Lazy<string> Expensive
+            {
+                get { return expensive; }
+            }
+
+            [Inject]
+            public NeedsAnExpensiveObject(Lazy<string> expensive)
+            {
+                this.expensive = expensive;
+            }
+        }
+    }
+}

--- a/test/Stiletto.Tests/ProviderInjectionTests.cs
+++ b/test/Stiletto.Tests/ProviderInjectionTests.cs
@@ -1,0 +1,51 @@
+using Xunit;
+
+namespace Stiletto.Tests
+{
+    public class ProviderInjectionTests
+    {
+        private readonly NeedsProvider testObj;
+        private readonly TestModule module;
+
+        public ProviderInjectionTests()
+        {
+            module = new TestModule();
+            var container = Container.Create(module);
+            testObj = container.Get<NeedsProvider>();
+        }
+
+        [Fact]
+        public void CanInjectProviderOfT()
+        {
+            Assert.NotNull(testObj.ObjectProvider);
+        }
+
+        [Fact]
+        public void InjectedProviderInvokesProviderMethod()
+        {
+            Assert.Equal(0, module.Invocations);
+            testObj.ObjectProvider.Get();
+            testObj.ObjectProvider.Get();
+            Assert.Equal(2, module.Invocations);
+        }
+
+        [Module(Injects = new[] { typeof(NeedsProvider) })]
+        public class TestModule
+        {
+            public int Invocations = 0;
+
+            [Provides]
+            public string SomeObject()
+            {
+                ++Invocations;
+                return new string("abcdefg".ToCharArray());
+            }
+        }
+
+        public class NeedsProvider
+        {
+            [Inject]
+            public IProvider<string> ObjectProvider { get; set; }
+        }
+    }
+}

--- a/test/Stiletto.Tests/SetInjectionTests.cs
+++ b/test/Stiletto.Tests/SetInjectionTests.cs
@@ -1,0 +1,173 @@
+using Xunit;
+
+namespace Stiletto.Tests
+{
+    public class SetInjectionTests
+    {
+        [Fact]
+        public void SetBindings_ContributeToInjectedSet()
+        {
+            var needsSet = Container.Create(new NeedsSetModule()).Get<NeedsSet>();
+            Assert.Contains("foo", needsSet.Strings);
+            Assert.Contains("bar", needsSet.Strings);
+            Assert.Equal(2, needsSet.Strings.Count);
+        }
+
+        [Fact]
+        public void NamedSetsWork()
+        {
+            var names = Container.Create(new HasNamedSetsModule()).Get<HasNamedSets>();
+            Assert.Equal(2, names.BoyNames.Count);
+            Assert.Equal(2, names.GirlNames.Count);
+            Assert.Contains("Billie", names.BoyNames);
+            Assert.Contains("Cory", names.BoyNames);
+            Assert.Contains("Pat", names.GirlNames);
+            Assert.Contains("Devon", names.GirlNames);
+        }
+
+        [Fact]
+        public void SetElementsCanBeSingletons()
+        {
+            var sets = Container.Create(typeof(SingletonSetElementModule)).Get<HasSingletonSetElement>();
+            Assert.True(sets.SetOne.Overlaps(sets.SetTwo));
+        }
+
+        [Fact]
+        public void SetElements_InLibraryModules_AreNotSubjectToOrphanAnalysis()
+        {
+            var container = Container.Create(typeof(ModuleWithLibraryOrphanStringSet));
+            container.Validate();
+        }
+
+        [Fact]
+        public void SetElements_InNonLibraryModules_AreSubjectToOrphanAnalysis()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(ModuleWithNonLibraryOrphanStringSet)).Validate());
+        }
+
+        public class NeedsSet
+        {
+            [Inject]
+            public ISet<string> Strings { get; set; }
+        }
+
+        [Module(Injects = new[] { typeof(NeedsSet) })]
+        public class NeedsSetModule
+        {
+            [Provides(ProvidesType.Set)]
+            public string ProvideFoo()
+            {
+                return "foo";
+            }
+
+            [Provides(ProvidesType.Set)]
+            public string ProvidesBar()
+            {
+                return "bar";
+            }
+        }
+
+        public class HasNamedSets
+        {
+            [Inject, Named("boy-names")]
+            public ISet<string> BoyNames { get; set; }
+
+            [Inject, Named("girl-names")]
+            public ISet<string> GirlNames { get; set; }
+        }
+
+        [Module(Injects = new[] { typeof(HasNamedSets) })]
+        public class HasNamedSetsModule
+        {
+            [Provides(ProvidesType.Set), Named("boy-names")]
+            public string ProvideNameOne()
+            {
+                return "Cory";
+            }
+
+            [Provides(ProvidesType.Set), Named("girl-names")]
+            public string ProvideNameTwo()
+            {
+                return "Devon";
+            }
+
+            [Provides(ProvidesType.Set), Named("boy-names")]
+            public string ProvideNameThree()
+            {
+                return "Billie";
+            }
+
+            [Provides(ProvidesType.Set), Named("girl-names")]
+            public string ProvideNameFour()
+            {
+                return "Pat";
+            }
+        }
+
+        public class HasSingletonSetElement
+        {
+            public ISet<object> SetOne { get; private set; }
+            public ISet<object> SetTwo { get; private set; }
+
+            [Inject]
+            public HasSingletonSetElement(ISet<object> setOne, ISet<object> setTwo)
+            {
+                SetOne = setOne;
+                SetTwo = setTwo;
+            }
+        }
+
+        [Module(Injects = new[] { typeof(HasSingletonSetElement) })]
+        public class SingletonSetElementModule
+        {
+            [Provides(ProvidesType.Set), Singleton]
+            public object ProvideSingletonObject()
+            {
+                return new object();
+            }
+
+            [Provides(ProvidesType.Set)]
+            public object ProvideTransientObject()
+            {
+                return new object();
+            }
+        }
+
+        public class NeedsNothing
+        {
+        }
+
+        [Module(IsLibrary = true)]
+        public class StringSetLibraryModule
+        {
+            [Provides(ProvidesType.Set)]
+            public string ProvideString()
+            {
+                return "foo";
+            }
+        }
+
+        [Module(Injects = new[] { typeof(NeedsNothing) },
+            IncludedModules = new[] { typeof(StringSetLibraryModule) })]
+        public class ModuleWithLibraryOrphanStringSet
+        {
+        }
+
+        [Module]
+        public class StringSetNonLibraryModule
+        {
+            [Provides(ProvidesType.Set)]
+            public string ProvideAnotherString()
+            {
+                return "bar";
+            }
+        }
+
+        [Module(Injects = new[] { typeof(NeedsNothing) },
+            IncludedModules = new[] { typeof(StringSetLibraryModule), typeof(StringSetNonLibraryModule) })]
+        public class ModuleWithNonLibraryOrphanStringSet
+        {
+        }
+    }
+}

--- a/test/Stiletto.Tests/ValidatorTests.cs
+++ b/test/Stiletto.Tests/ValidatorTests.cs
@@ -1,0 +1,261 @@
+using Xunit;
+
+namespace Stiletto.Tests
+{
+    public class ValidatorTests
+    {
+        [Fact]
+        public void Validate_WhenDependencyIsUnsatisfied_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(NeedsSomethingMore)).Validate());
+        }
+
+        [Fact]
+        public void Validate_WhenCircularDependenciesExist_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(CaptainPlanet)).Validate());
+        }
+
+        [Fact]
+        public void Validate_WhenCircularDependenciesExistAcrossModules_Throws()
+        {
+            var container = Container.Create(typeof(BadModuleOne), typeof(BadModuleTwo));
+            Assert.Throws<InvalidOperationException>(() => container.Validate());
+        }
+
+        [Fact]
+        public void Validate_WhenNoCyclesExist_DoesNotThrow()
+        {
+            var container = Container.Create(typeof(GoodModuleOne), typeof(GoodModuleTwo));
+            container.Validate();
+        }
+
+        [Fact]
+        public void Validate_WhenProviderMethodsAreUnused_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(UnusedProvidesModule)).Validate());
+        }
+
+        [Fact]
+        public void Validate_WhenProviderParamMissing_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(MissingProviderParamModule)).Validate());
+        }
+
+        [Fact]
+        public void Validate_WithCircularDependencies_AcrossProvidersAndInjectables_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => Container.Create(typeof(CircularModule)).Validate());
+        }
+
+        [Fact]
+        public void NonProvidedInjectableProviderParamIsValid()
+        {
+            var container = Container.Create(typeof(NonProvidedImplementationModule));
+            container.Validate();
+        }
+
+        [Module(Injects = new[] { typeof(Dep) })]
+        public class NeedsSomethingMore
+        {
+            public class Dep
+            {
+                [Inject]
+                public string Str { get; set; }
+
+                [Inject]
+                public object Bar { get; set; }
+            }
+
+            [Provides]
+            public string GetString()
+            {
+                return "foo";
+            }
+        }
+
+        public class Earth
+        {
+            [Inject]
+            public Wind Wind { get; set; }
+        }
+
+        public class Wind
+        {
+            [Inject]
+            public Fire Fire { get; set; }
+        }
+
+        public class Fire
+        {
+            [Inject]
+            public Water Water { get; set; }
+        }
+
+        public class Water
+        {
+            [Inject]
+            public Heart Heart { get; set; }
+        }
+
+        public class Heart
+        {
+            [Inject]
+            public Earth Earth { get; set; }
+        }
+
+        [Module(Injects = new[] { typeof(CaptainPlanet) })]
+        public class CaptainPlanet
+        {
+            public CaptainPlanet()
+            {
+            }
+
+            [Inject]
+            public CaptainPlanet(Earth earth, Wind wind, Fire fire, Water water, Heart heart)
+            {
+            }
+        }
+
+        public class UnusedProvidesInjectable
+        {
+            [Inject]
+            public string Foo { get; set; }
+        }
+
+        [Module(Injects = new[] { typeof(UnusedProvidesInjectable) })]
+        public class UnusedProvidesModule
+        {
+            [Provides]
+            public string ProvideString()
+            {
+                return "foo";
+            }
+
+            [Provides]
+            public int ProvideInt()
+            {
+                return -1;
+            }
+        }
+
+        [Module(IsComplete = false)]
+        public class BadModuleOne
+        {
+            [Provides]
+            public string Foo(int i)
+            {
+                return "";
+            }
+        }
+
+        [Module(IsComplete = false)]
+        public class BadModuleTwo
+        {
+            [Provides]
+            public int Bar(string s)
+            {
+                return 0;
+            }
+        }
+
+        [Module(IsComplete = false, IsLibrary = true)]
+        public class GoodModuleOne
+        {
+            [Provides]
+            public string Foo(int i)
+            {
+                return "";
+            }
+        }
+
+        [Module(IsLibrary = true)]
+        public class GoodModuleTwo
+        {
+            [Provides]
+            public int Bar()
+            {
+                return 0;
+            }
+        }
+
+        [Module(IsLibrary = true)]
+        public class MissingProviderParamModule
+        {
+            [Provides]
+            public int Bar(string foo)
+            {
+                return foo.GetHashCode();
+            }
+
+            [Provides]
+            public string GetString(object bar)
+            {
+                return bar.ToString();
+            }
+        }
+
+        public interface IClass
+        {
+            int GetInt { get; set; }
+        }
+
+        public class SomeClass : IClass
+        {
+            public int GetInt { get; set; }
+
+            [Inject]
+            public SomeClass(int num)
+            {
+                GetInt = num;
+            }
+        }
+
+        [Module]
+        public class CircularModule
+        {
+            [Provides]
+            public IClass One(SomeClass impl)
+            {
+                return impl;
+            }
+
+            [Provides]
+            public int Two(IClass provider)
+            {
+                return provider.GetInt;
+            }
+        }
+
+        public class SomeOtherClass : IClass
+        {
+            public int GetInt { get; set; }
+
+            [Inject]
+            public SomeOtherClass(string str)
+            {
+            }
+        }
+
+        [Module(IsLibrary = true)]
+        public class NonProvidedImplementationModule
+        {
+            [Provides]
+            public string ProvideString()
+            {
+                return "foo";
+            }
+
+            [Provides]
+            public IClass ProvideClass(SomeOtherClass impl)
+            {
+                return impl;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bring over the Stiletto.Test and IntegrationTests cases that still describe distinct behavior under the source generator:

- Stiletto.Tests (reflection runtime): LazyInjectionTests, ProviderInjectionTests, SetInjectionTests, ValidatorTests, and the remaining KeyTestsBase cases folded into KeyTests. Converted from NUnit/ExpectBetter to xUnit.
- Stiletto.Integration.Tests (generator-driven): a new Stiletto.Integration.External assembly plus CrossAssemblyTests prove per-assembly CompiledLoaders aggregate at runtime; GeneratedGraphValidationTests ports the old build-failure cases (circular deps, unused providers, duplicate injects) as runtime behaviors on compiled bindings.

Integration cases that no longer describe distinct behavior in the source-generator world (LoaderIsGenerated, InjectTypesGetCompiledBinding, ContainerCreateCallsRewritten, the orphan-set builds) are covered by the above and the existing ToolchainEndToEndTests, so they are not re-added.