### PR TITLE
ci: publish www to Pages via a manual deploy workflow

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -1,0 +1,43 @@
+name: Deploy www
+
+# Publishes the marketing site in `www/` to GitHub Pages
+# (https://stiletto.bendb.com). The site's source of truth is `www/` on
+# master; this workflow is the only thing that writes to Pages. Deploys are
+# manual only — trigger from the Actions tab ("Run workflow"). It publishes
+# whatever `www/` looks like on the ref you run it against (default: master).
+
+on:
+  workflow_dispatch:
+
+# Allow the deploy job to publish to Pages via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One live deploy at a time; don't cancel an in-flight publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload www artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: www
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/www/CNAME
+++ b/www/CNAME
@@ -1,0 +1,1 @@
+stiletto.bendb.com

--- a/www/google28922fbc71f875bb.html
+++ b/www/google28922fbc71f875bb.html
@@ -1,0 +1,1 @@
+google-site-verification: google28922fbc71f875bb.html


### PR DESCRIPTION
Make `www/` on master the self-contained source of truth for the marketing site (stiletto.bendb.com) and add a manual GitHub Actions deploy, replacing the hand-maintained gh-pages branch.

- www/CNAME and www/google28922fbc71f875bb.html: the deploy-only files that previously lived only at the gh-pages root, so www/ deploys as-is.
- .github/workflows/deploy-www.yml: workflow_dispatch-only deploy that uploads www/ and publishes via actions/deploy-pages.

Going live still requires flipping the repo Pages source from the gh-pages branch to GitHub Actions.