### PR TITLE
build: remove obsolete .nuget/NuGet.Config

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <solution>
-    <add key="disableSourceControlIntegration" value="true" />
-  </solution>
-</configuration>


### PR DESCRIPTION
It contained only the VS2013-era solution setting
`disableSourceControlIntegration` for the legacy packages.config/packages-folder restore — a no-op for modern SDK-style (PackageReference) restore, and it defines no package sources. Nothing in the build references it.